### PR TITLE
Revert "socrates: overlay: Rework supported color modes"

### DIFF
--- a/overlay/FrameworkResOverlaySocrates/res/values/config.xml
+++ b/overlay/FrameworkResOverlaySocrates/res/values/config.xml
@@ -114,11 +114,9 @@
 
     <!-- Indicate available ColorDisplayManager.COLOR_MODE_xxx. -->
     <integer-array name="config_availableColorModes">
-        <item>258</item> <!-- vivid -->
-        <item>256</item> <!-- saturated -->
-        <item>257</item> <!-- original -->
-        <item>268</item> <!-- p3 -->
-        <item>267</item> <!-- srgb -->
+        <item>0</item>
+        <item>1</item>
+        <item>3</item>
     </integer-array>
 
     <!-- Configure mobile tcp buffer sizes in the form:

--- a/overlay/SettingsOverlaySocrates/res/values/config.xml
+++ b/overlay/SettingsOverlaySocrates/res/values/config.xml
@@ -24,28 +24,6 @@
      entries do not follow the convention, but all new entries should. -->
 
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <!-- Display settings screen, Color mode options. Must be the same length and order as
-         config_color_mode_options_values below. Only the values that also appear in
-         frameworks/base/core/res/res/values/config.xml's config_availableColorModes are shown. -->
-    <string-array name="config_color_mode_options_strings" translatable="false">
-        <item>Vivid</item>
-        <item>Saturated</item>
-        <item>Original</item>
-        <item>P3</item>
-        <item>sRGB</item>
-    </string-array>
-
-    <!-- Display settings screen, Color mode options. Must be the same length and order as
-         config_color_mode_options_strings above. Only the values that also appear in
-         frameworks/base/core/res/res/values/config.xml's config_availableColorModes are shown. -->
-    <integer-array name="config_color_mode_options_values" translatable="false">
-        <item>258</item>
-        <item>256</item>
-        <item>257</item>
-        <item>268</item>
-        <item>267</item>
-    </integer-array>
-
     <!-- The radius of the enrollment progress bar, in dp -->
     <integer name="config_udfpsEnrollProgressBar">
         75


### PR DESCRIPTION
It seems that these color modes is not supported by Redmi K60 Pro. This reverts commit c0f7b835fbe28da7e1fae574a02d6de8856321ec.