### PR TITLE
socrates: Fix `user` build type

### DIFF
--- a/lineage_socrates.mk
+++ b/lineage_socrates.mk
@@ -20,4 +20,4 @@ PRODUCT_MODEL := Redmi K60 Pro
 PRODUCT_BRAND := Redmi
 PRODUCT_MANUFACTURER := Xiaomi
 
-BUILD_FINGERPRINT := Redmi/socrates/socrates:14/UKQ1.230804.001/V816.0.9.0.UMKCNXM:user/release-keys
+BUILD_FINGERPRINT := Redmi/socrates/socrates:13/UKQ1.230804.001/V816.0.9.0.UMKCNXM:user/release-keys


### PR DESCRIPTION
Difference between fingerprint in lineage_socrates.mk makefile and proprietary vendor cause bootloop at user build type.